### PR TITLE
Start documenting examples for get_records.rst

### DIFF
--- a/source/Reference/libraries/globals/examples/get_records.rst
+++ b/source/Reference/libraries/globals/examples/get_records.rst
@@ -1,0 +1,23 @@
+``get_records()`` retrieves different kind of records from the database. You can use it when other record queries don't work for you.
+
+.. code-block:: php
+
+    $items = get_records('Item',array('tags'=>$itemTags, 'range'=>$itemIds, 'collection'=>$itemCollection, 'type'=>$itemType),50);
+    
+This example uses four different parameters in the ``$params`` array to narrow down the range of **items** selected:
+
+- ``tags`` uses a string of tag names to lookup items by tag
+- ``range`` allows you to select records by ID ranges. For example: ``1-5,8,15``
+- ``collection`` allows you to select a given collection ID.
+- ``type`` allows you to select a given item type by ID. 
+
+.. code-block:: php
+    
+    $exhibits = get_records('Exhibit', array('slug'=>$exhibitSlugs, 'tags'=>$exhibitTags), 50);
+
+This example uses two different parameters in the ``$params`` array to narrow down the range of **exhibits** selected:
+
+- ``slug`` allows you to select exhibits by comma-separated slugs
+- ``tags`` uses a string of tag names to lookup exhibits by tag
+
+In both cases, you can then iterate through the array of records that is returned in order to display them or perform further processing.

--- a/source/Reference/libraries/globals/examples/get_records.rst
+++ b/source/Reference/libraries/globals/examples/get_records.rst
@@ -21,3 +21,5 @@ This example uses two different parameters in the ``$params`` array to narrow do
 - ``tags`` uses a string of tag names to lookup exhibits by tag
 
 In both cases, you can then iterate through the array of records that is returned in order to display them or perform further processing.
+
+The complete list of parameters that you can filter records by can be found in the model objects that extend **Omeka_Db_Table**. See list of classes in the  ``application/models/Table`` directory. In particular, look at the ``applySearchFilters()`` method that is attached to each class.


### PR DESCRIPTION
This PR adds some examples for the `get_records()` global function in the `get_records.rst` file. Inspired by the [Omeka docathon](http://omeka.readthedocs.io/en/latest/Helping/index.html).

@jaguillette @bilbe @brandonATG contributed to this documentation.

