### PR TITLE
Update random_featured_items summary

### DIFF
--- a/source/Reference/libraries/globals/random_featured_items.rst
+++ b/source/Reference/libraries/globals/random_featured_items.rst
@@ -18,7 +18,8 @@ Summary
     
     :type $count: int
     :param $count: Maximum number of items to show.
-    :param $hasImage:
+    :type $hasImage: bool
+    :param $hasImage: Whether or not the featured items must have images associated. If null, as default, all featured items can appear, whether or not they have files. If true, only items with files will appear, and if false, only items without files will appear.
     :returns: string
 
 *****


### PR DESCRIPTION
Updated summary to add type and description of $hasImage param to match comments in globals.php on [line 2310](https://github.com/omeka/Omeka/blob/dfb903f9050cce36fa39cd8b5efe5d7503013534/application/libraries/globals.php#L2310-L2313)

This follows a conversation with @patrickmj yesterday on how best to contribute to docs. Is this the best way to make these changes? Or would it be better to file an issue with links to the doc and commented code to let you all make the change?