### PR TITLE
Added the recipe Display Different Header Images

### DIFF
--- a/source/Tutorials/recipes/displayDifferentHeaderImages.rst
+++ b/source/Tutorials/recipes/displayDifferentHeaderImages.rst
@@ -1,0 +1,38 @@
+.. _recipesDisplayDifferentHeaderImages:
+
+
+###############################
+Display Different Header Images
+###############################
+
+********
+Problem
+********
+
+I want to display a different header image if the page is a SimplePages page.
+
+********
+Solution
+********
+
+In the theme's header.php file, usually in theme/common/header.php, add the following code to change the image if the page is a SimplePage. This example comes from default theme::
+
+    <header role="banner">
+        <div id="site-title">
+        <?php if ($bodyclass=='page simple-page'):?>
+            <img src="my_image.jpg" alt="my_alt_text"/>
+        <?php else: ?>
+            <?php echo link_to_home_page(theme_logo()); ?>
+        <?php endif ?>
+        </div>
+    </header>
+
+In the site title div, the original code for the theme was::
+
+    <header role="banner">
+        <div id="site-title">
+        <?php echo link_to_home_page(theme_logo()); ?>
+        </div>
+    </header>
+
+The changes here check whether we're on a simple page, and if so will display your image of choice. Otherwise, it instead displays the theme logo.


### PR DESCRIPTION
Hello,

I added a new recipe to Omeka’s documentation. The recipe allows you to add custom header images to simple pages in Omeka. It was based on a recipe someone else designed for Omeka 1.0, but I upgraded it so it works for the current version of Omeka. Have a nice day.